### PR TITLE
Only push changes in the output directory

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,12 +73,6 @@ fi
 # Fetch the second agument (Generated HTML documents output folder) and
 # strip the '/' character from the end of the directory path (if there is any)
 HTMLOUTPUT=${2%/}
-if [ -d "$HTMLOUTPUT" ]; then
-    echo "Generated HTML documents output folder: $HTMLOUTPUT"
-else
-    echo "HTML documents output folder cannot be found at: $HTMLOUTPUT"
-    exit 1
-fi
 
 # Fetch the third argument (GitHub Pages branch name)
 GHPAGESBRANCH=$3
@@ -99,6 +93,14 @@ fi
 # Try to generate code documentation
 # Exit with error if the document generation failed
 doxygen "$DOXYGENCONF" || exit 1
+
+# Check for existence of HTML output folder
+if [ -d "$HTMLOUTPUT" ]; then
+    echo "Generated HTML documents output folder: $HTMLOUTPUT"
+else
+    echo "HTML documents output folder cannot be found at: $HTMLOUTPUT"
+    exit 1
+fi
 
 ConfigureGitUser
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,11 +53,16 @@ MigrateChanges () {
 }
 
 CommitChanges () {
-    # Add all the changes to the GIT
-    git add --all
+    DESTINATIONDIR=$1
+    
+    # Unstage all changes
+    git reset
+    
+    # Add only the destination directory
+    git add --force "$DESTINATIONDIR"
     
     # Commit all the changed to the the GitHub Pages branch
-    git commit -m "Auto commit."
+    git commit -m "Auto commit"
     
     # Push the changes to the remote GitHub Pages branch
     git push
@@ -112,4 +117,4 @@ fi
 
 DisableJekyll "$GHPAGESDIR"
 
-CommitChanges
+CommitChanges "$GHPAGESDIR"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,13 +26,13 @@ GetCurrentBranch () {
 PrepareGitHubPagesDirectory() {
 	DESTINATIONDIR=$1
 	
+    # Remove all the files in GitHub Pages directory (if the directory exists)
 	if [ -d "$DESTINATIONDIR" ]; then
-        # Remove all the files in GitHub Pages directory (if the directory exists)
         git rm -rf "$DESTINATIONDIR"
-    else
-        # Create the GitHub Pages directory if it does not exist
-        mkdir -p "$DESTINATIONDIR"
     fi
+    
+    # Create the GitHub Pages directory if it does not exist
+    mkdir -p "$DESTINATIONDIR"
 }
 
 MigrateChanges () {
@@ -53,7 +53,7 @@ MigrateChanges () {
     # Exit with error if the checkout failed
     git checkout "$DESTINATIONBRANCH" || exit 1
     
-    # Prepare destination directory once again
+    # Prepare destination directory
     PrepareGitHubPagesDirectory "$DESTINATIONDIR"
 
     # Pop the stashed generated code documentation
@@ -97,9 +97,6 @@ GHPAGESDIR=$4
 
 InstallDependencies
 
-# Prepare destination directory
-PrepareGitHubPagesDirectory "$GHPAGESDIR"
-
 # Try to generate code documentation
 # Exit with error if the document generation failed
 doxygen "$DOXYGENCONF" || exit 1
@@ -125,6 +122,9 @@ fi
 # Move the the generated code documentation to the GitHub Pages directory
 # if two directories are not the same.
 if [ ! "$(realpath "$GHPAGESDIR")" -ef "$(realpath "$HTMLOUTPUT")" ]; then
+    # Prepare destination directory
+    PrepareGitHubPagesDirectory "$GHPAGESDIR"
+    
     mv "$HTMLOUTPUT"/* "$GHPAGESDIR"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,6 +23,18 @@ GetCurrentBranch () {
     echo "$(git rev-parse --abbrev-ref HEAD)"
 }
 
+PrepareGitHubPagesDirectory() {
+	DESTINATIONDIR=$1
+	
+	if [ -d "$DESTINATIONDIR" ]; then
+        # Remove all the files in GitHub Pages directory (if the directory exists)
+        git rm -rf "$DESTINATIONDIR"
+    else
+        # Create the GitHub Pages directory if it does not exist
+        mkdir -p "$DESTINATIONDIR"
+    fi
+}
+
 MigrateChanges () {
     SOURCEDIR=$1
     DESTINATIONBRANCH=$2
@@ -40,6 +52,9 @@ MigrateChanges () {
     # Try to switch to the GitHub Pages branch
     # Exit with error if the checkout failed
     git checkout "$DESTINATIONBRANCH" || exit 1
+    
+    # Prepare destination directory once again
+    PrepareGitHubPagesDirectory "$DESTINATIONDIR"
 
     # Pop the stashed generated code documentation
     git stash pop
@@ -82,13 +97,8 @@ GHPAGESDIR=$4
 
 InstallDependencies
 
-if [ -d "$GHPAGESDIR" ]; then
-    # Remove all the files in GitHub Pages directory (if the directory exists)
-    git rm -rf "$GHPAGESDIR"
-else
-    # Make the GitHub Pages directory if it does not exist
-    mkdir -p "$GHPAGESDIR"
-fi
+# Prepare destination directory
+PrepareGitHubPagesDirectory "$GHPAGESDIR"
 
 # Try to generate code documentation
 # Exit with error if the document generation failed


### PR DESCRIPTION
This action runs into problems when there are untracked files present in the repository (in my case, for example, I generate some files and also the Doxyfile dynamically using CMake). Files outside of Doxygen's output directory are then committed and pushed, and when the action runs for a second time then, it just deletes all the files.

I have fixed the script so that it will also work for me, and it seems to work now (you can have a look at the actions in the jatofg/nawa repository if you wish). Feel free to test the changes and merge them.