### PR TITLE
Resolve action failing if there is nothing to commit 

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -104,6 +104,7 @@ CommitChanges () {
 	# Push the changes to the remote GitHub Pages branch
     	git push
     else
+    	echo "There is no change in the documentation"
     	exit 0
     fi
  

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -94,11 +94,19 @@ CommitChanges () {
     # Add only the destination directory
     git add --force "$DESTINATIONDIR"
     
-    # Commit all the changed to the the GitHub Pages branch
-    git commit -m "Auto commit" || exit 0
-    
-    # Push the changes to the remote GitHub Pages branch
-    git push
+    #check if there are any changes that are staged but not committed
+    if (! git diff --cached --exit-code --shortstat) 
+    then
+   	
+	# Commit all the changed to the the GitHub Pages branch
+    	git commit -m "Auto commit" || exit 1
+   	
+	# Push the changes to the remote GitHub Pages branch
+    	git push
+    else
+    	exit 0
+    fi
+ 
 }
 
 # Fetch the first argument (Doxygen configuration file path)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -95,7 +95,7 @@ CommitChanges () {
     git add --force "$DESTINATIONDIR"
     
     # Commit all the changed to the the GitHub Pages branch
-    git commit -m "Auto commit" || exit 1
+    git commit -m "Auto commit" || exit 0
     
     # Push the changes to the remote GitHub Pages branch
     git push


### PR DESCRIPTION
The action will fail if it is invoked without any change to the documentation

To resolve this issue changing "exit 1" in "exit 0" is enough