### PR TITLE
Update alpine linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Specifies the container official image to run the codes
 # Same as the action itself, Alpine is also a minial Docker image (More info: https://hub.docker.com/_/alpine)
-FROM alpine:3.15.4
+FROM alpine:3.22.0
 
 # Copies the container entrypoint Bash script file from the action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -72,3 +72,4 @@ Following is the latest doxygenize version:
 | Release version | Docker image | Tag aliases |
 | --------------- | ------------ | ----------  |
 | v1.7.0 | Alpine 3.15.4 | v1, v1.7 |
+| v1.7.0 | Alpine 3.22.0 | v1, v1.7 |

--- a/README.md
+++ b/README.md
@@ -71,5 +71,4 @@ Following is the latest doxygenize version:
 
 | Release version | Docker image | Tag aliases |
 | --------------- | ------------ | ----------  |
-| v1.7.0 | Alpine 3.15.4 | v1, v1.7 |
-| v1.7.0 | Alpine 3.22.0 | v1, v1.7 |
+| v1.7.1 | Alpine 3.22.0 | v1, v1.7 |


### PR DESCRIPTION
Update deprecated Alpine Linux (also to get a newer Doxygen 1.13.2-r0 release)