### PR TITLE
creating HTML output path (Doxygen might fail)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -163,6 +163,9 @@ if [ "$CUSTOMHEADER" != "" ]; then
     ConfigureCustomHeader "$DOXYGENCONF" "$CUSTOMHEADER"
 fi
 
+# Create the HTML output path (e.g. site/html), as Doxygen does not support creating multiple parent directories
+mkdir -p "$HTMLOUTPUT"
+
 # Try to generate code documentation
 # Exit with error if the document generation failed
 doxygen "$DOXYGENCONF" || exit 1


### PR DESCRIPTION
If this is set in Doxyfile
`HTML_OUTPUT            = ./site/api`
(and `htmloutput: ./site/api` in yaml)
Doxygen will fail if `site` is not available (looks like Doxygen can only create one level of directory hierarchie).

BTW: I would also propose to remove the yaml option `htmloutput`
and replace it in `entrypoint.sh` by
```
HTMLOUTPUT=`grep HTML_OUTPUT $DOXYGENCONF | cut -d "=" -f 2- | xargs`
```